### PR TITLE
Fix slow server fetching in Release mode

### DIFF
--- a/H2MLauncher.Core/H2MLauncher.Core.csproj
+++ b/H2MLauncher.Core/H2MLauncher.Core.csproj
@@ -10,6 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Awesome.Net.WritableOptions" Version="3.0.0" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />
+    <PackageReference Include="Haukcode.HighResolutionTimer" Version="1.1.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
   </ItemGroup>

--- a/H2MLauncher.Core/Services/GameServerCommunication.cs
+++ b/H2MLauncher.Core/Services/GameServerCommunication.cs
@@ -39,6 +39,7 @@ namespace H2MLauncher.Core.Services
             _client.Client.DualMode = true; // enables both IPv4 and IPv6
             _client.Client.Bind(new IPEndPoint(IPAddress.IPv6Any, 0)); // bind to any available port
             _client.Client.ReceiveTimeout = 5000;
+            _client.Client.SendBufferSize = 1000;
 
             // Set control flag to avoid connection reset when port is unreachable
             // (https://stackoverflow.com/a/7478498/4711541
@@ -49,7 +50,7 @@ namespace H2MLauncher.Core.Services
 
             _synchronizationContext = SynchronizationContext.Current ?? new();
         }
-
+        
         private void HandleMessage(UdpReceiveResult result, DateTimeOffset timestamp)
         {
             string receivedMessage = Encoding.UTF8.GetString(result.Buffer);

--- a/H2MLauncher.Core/Services/GameServerCommunicationService.cs
+++ b/H2MLauncher.Core/Services/GameServerCommunicationService.cs
@@ -130,7 +130,7 @@ namespace H2MLauncher.Core.Services
                 });
             
             using HighResolutionTimer timer = new();
-            timer.SetPeriod(2);
+            timer.SetPeriod(1);
             timer.Start();
 
             foreach (var serverEndpoint in serverInfoMap.Keys)

--- a/H2MLauncher.UI/ViewModels/ServerBrowserViewModel.cs
+++ b/H2MLauncher.UI/ViewModels/ServerBrowserViewModel.cs
@@ -365,7 +365,7 @@ public partial class ServerBrowserViewModel : ObservableObject
                 .OrderByDescending((server) => server.ClientNum);
 
             // Start by sending info requests to the game servers
-            await _gameServerCommunicationService.StartRetrievingGameServerInfo(serversOrderedByOccupation, (server, gameServer) =>
+            await Task.Run(() => _gameServerCommunicationService.StartRetrievingGameServerInfo(serversOrderedByOccupation, (server, gameServer) =>
             {
                 bool isFavorite = userFavorites.Any(fav => fav.ServerIp == server.Ip && fav.ServerPort == server.Port);
 
@@ -397,7 +397,7 @@ public partial class ServerBrowserViewModel : ObservableObject
 
                 // Game server responded -> online
 
-            }, _loadCancellation.Token);
+            }, _loadCancellation.Token));
             StatusText = "Ready";
         }
         catch (OperationCanceledException ex)


### PR DESCRIPTION
The getInfo sending was taking way longer when not debugging, due to the `Task.Delay(1)` actually taking 15ms. 

Adding a high resolution timer fixed this issue.