### PR TITLE
Fix HMW stuff

### DIFF
--- a/H2MLauncher.Core/Game/GameDirectoryService.cs
+++ b/H2MLauncher.Core/Game/GameDirectoryService.cs
@@ -17,7 +17,7 @@ namespace H2MLauncher.Core.Services
 
         private const string CONFIG_MP_FILENAME = "config_mp.cfg";
         private const string PLAYERS2_DIR = "players2";
-        private const string USERMAPS_DIR = "h2m-usermaps";
+        private const string USERMAPS_DIR = "hmw-usermaps";
 
         private FileSystemWatcher? _fileSystemWatcher;
         private readonly IOptionsMonitor<H2MLauncherSettings> _optionsMonitor;

--- a/H2MLauncher.UI/App.xaml.cs
+++ b/H2MLauncher.UI/App.xaml.cs
@@ -57,9 +57,6 @@ namespace H2MLauncher.UI
 
             ServiceProvider = serviceCollection.BuildServiceProvider();
 
-            MainWindow mainWindow = ServiceProvider.GetRequiredService<MainWindow>();
-            mainWindow.Show();
-
             // save options on startup to update user file with new settings            
             ServiceProvider.GetRequiredService<IWritableOptions<H2MLauncherSettings>>().Update((settings) =>
             {
@@ -69,11 +66,17 @@ namespace H2MLauncher.UI
                     IW4MMasterServerUrl = string.IsNullOrEmpty(settings.IW4MMasterServerUrl)
                         ? _defaultSettings.IW4MMasterServerUrl
                         : settings.IW4MMasterServerUrl,
-                    HMWMasterServerUrl = string.IsNullOrEmpty(settings.HMWMasterServerUrl)
-                        ? _defaultSettings.HMWMasterServerUrl
-                        : settings.HMWMasterServerUrl,
+
+                    // always override with the default url because there is only one master (and no option to change in the UI)
+                    HMWMasterServerUrl = _defaultSettings.HMWMasterServerUrl,
                 };
             });
+
+            // NOTE: this is really stupid but necessary to have the latest urls we just set above available
+            config.Reload();
+
+            MainWindow mainWindow = ServiceProvider.GetRequiredService<MainWindow>();
+            mainWindow.Show();
 
             base.OnStartup(e);
         }

--- a/H2MLauncher.UI/MainWindow.xaml
+++ b/H2MLauncher.UI/MainWindow.xaml
@@ -243,7 +243,7 @@
                         <Separator Opacity="0" Width="5" />
                         <Button TabIndex="4" Content="Refresh" Width="80" Command="{Binding RefreshServersCommand}"/>
                         <Separator Opacity="0" Width="5" />
-                        <Button TabIndex="5" Content="Launch H2M" Width="80" Command="{Binding LaunchH2MCommand}"/>
+                        <Button TabIndex="5" Content="Launch 🚀" Width="80" Command="{Binding LaunchH2MCommand}"/>
                     </StackPanel>
                 </Grid>
 

--- a/H2MLauncher.UI/Properties/AssemblyInfo.cs
+++ b/H2MLauncher.UI/Properties/AssemblyInfo.cs
@@ -13,7 +13,7 @@ using System.Windows;
 
 
 
-[assembly: AssemblyVersion("2.4.1.0")]
-[assembly: AssemblyFileVersion("2.4.1.0")]
+[assembly: AssemblyVersion("2.4.2.0")]
+[assembly: AssemblyFileVersion("2.4.2.0")]
 [assembly: AssemblyTitle("Better H2M-Launcher")]
 [assembly: SupportedOSPlatform("windows")]

--- a/H2MLauncher.UI/ViewModels/ServerBrowserViewModel.cs
+++ b/H2MLauncher.UI/ViewModels/ServerBrowserViewModel.cs
@@ -206,14 +206,14 @@ public partial class ServerBrowserViewModel : ObservableObject, IDisposable
             throw new Exception("Could not add all servers tab");
         }
 
-        if (!TryAddNewTab("H2M Servers", out ServerTabViewModel? h2mServersTab))
-        {
-            throw new Exception("Could not add H2M servers tab");
-        }
-
         if (!TryAddNewTab("HMW Servers", out ServerTabViewModel? hmwServersTab))
         {
             throw new Exception("Could not add HMW servers tab");
+        }
+
+        if (!TryAddNewTab("H2M Servers", out ServerTabViewModel? h2mServersTab))
+        {
+            throw new Exception("Could not add H2M servers tab");
         }
 
         if (!TryAddNewTab("Favourites", out ServerTabViewModel? favouritesTab))
@@ -237,7 +237,7 @@ public partial class ServerBrowserViewModel : ObservableObject, IDisposable
         HMWServersTab = hmwServersTab;
         FavouritesTab = favouritesTab;
 
-        SelectedTab = ServerTabs.First();
+        SelectedTab = HMWServersTab;
 
         foreach (IW4MObjectMap oMap in resourceSettings.Value.MapPacks.SelectMany(mappack => mappack.Maps))
         {
@@ -254,7 +254,8 @@ public partial class ServerBrowserViewModel : ObservableObject, IDisposable
         {
             Application.Current.Dispatcher.Invoke(() =>
             {
-                if (!oldSettings.IW4MMasterServerUrl.Equals(newSettings.IW4MMasterServerUrl))
+                if (!oldSettings.IW4MMasterServerUrl.Equals(newSettings.IW4MMasterServerUrl) ||
+                    !oldSettings.HMWMasterServerUrl.Equals(newSettings.HMWMasterServerUrl))
                 {
                     // refresh servers when master server url changes
                     RefreshServersCommand.Execute(null);

--- a/H2MLauncher.UI/appsettings.json
+++ b/H2MLauncher.UI/appsettings.json
@@ -27,7 +27,7 @@
   "H2MLauncher": {
     "MWRLocation": "",
     "IW4MMasterServerUrl": "http://master.iw4.zip",
-    "HMWMasterServerUrl": "https://ms.s2mod.to/game-servers",
+    "HMWMasterServerUrl": "https://ms.horizonmw.org/game-servers",
     "AutomaticGameDetection": true,
     "GameMemoryCommunication": true,
     "ServerQueueing": true,

--- a/MatchmakingServer/appsettings.json
+++ b/MatchmakingServer/appsettings.json
@@ -30,7 +30,7 @@
   "AllowedHosts": "*",
   "Settings": {
     "IW4MAdminMasterApiUrl": "https://master.iw4.zip",
-    "HMWMasterServerUrl": "https://ms.s2mod.to/game-servers"
+    "HMWMasterServerUrl": "https://ms.horizonmw.org/game-servers"
   },
   "QueueingSettings": {
     "QueueInactivityIdleTimeoutInS": 180,


### PR DESCRIPTION
update HMW master server url
always override HMW master server with default
fix options reloading after initial refresh
fix usermaps location ('h2m-usermaps' -> 'hmw-usermaps') reorder tabs