### PR TITLE
Fix command execution not working for some keyboard layouts

### DIFF
--- a/H2MLauncher.UI/Properties/AssemblyInfo.cs
+++ b/H2MLauncher.UI/Properties/AssemblyInfo.cs
@@ -13,7 +13,7 @@ using System.Windows;
 
 
 
-[assembly: AssemblyVersion("2.4.2.0")]
-[assembly: AssemblyFileVersion("2.4.2.0")]
+[assembly: AssemblyVersion("2.4.3.0")]
+[assembly: AssemblyFileVersion("2.4.3.0")]
 [assembly: AssemblyTitle("Better H2M-Launcher")]
 [assembly: SupportedOSPlatform("windows")]

--- a/H2MLauncher.UI/appsettings.json
+++ b/H2MLauncher.UI/appsettings.json
@@ -45,7 +45,7 @@
     }
   },
   "Matchmaking": {
-    "MatchmakingServerUrl": "http://v2202201165944175565.quicksrv.de:9100",
+    "MatchmakingServerUrl": "http://v2202201165944175565.quicksrv.de:9000",
     "UseRandomCliendId": false
   },
   "Resource": {

--- a/MatchmakingServer/GameServer.cs
+++ b/MatchmakingServer/GameServer.cs
@@ -46,7 +46,7 @@ namespace MatchmakingServer
 
         public List<string> ActualPlayers { get; } = [];
 
-        public string InstanceId { get; } = "";
+        public string InstanceId { get; init; } = "";
 
         public DateTimeOffset SpawnDate { get; init; } = DateTimeOffset.Now;
 

--- a/MatchmakingServer/SignalR/ServerStore.cs
+++ b/MatchmakingServer/SignalR/ServerStore.cs
@@ -29,6 +29,7 @@ namespace MatchmakingServer.SignalR
             // server does not have a queue yet, create new
             GameServer server = new()
             {
+                InstanceId = Guid.NewGuid().ToString(),
                 ServerIp = serverIp,
                 ServerPort = serverPort,
                 ServerName = serverName ?? "",
@@ -54,6 +55,7 @@ namespace MatchmakingServer.SignalR
                 // server does not have a queue yet, create new
                 GameServer server = new()
                 {
+                    InstanceId = Guid.NewGuid().ToString(),
                     ServerIp = serverIp,
                     ServerPort = serverPort,
                     ServerName = serverName ?? "",


### PR DESCRIPTION
Fix command execution not working for some keyboard layouts by using `WriteToConsoleInput` after attaching.

This should work independent of the keyboard layout and with both Windows and Conhost terminal.